### PR TITLE
Varchar (MAX) error

### DIFF
--- a/src/Writer/BCP.php
+++ b/src/Writer/BCP.php
@@ -99,6 +99,7 @@ class BCP
         $driverVersion = "{$this->getVersion()}";
         $columnsCount = count($table['items']) + 1;
         $prefixLength = 0;
+        $length = 0;
         $sourceType = "SQLCHAR";
 
         $delimiter = '"\""';
@@ -113,11 +114,6 @@ class BCP
         foreach ($table['items'] as $column) {
             $cnt++;
             $dstCnt = $cnt - 1;
-
-            $length = '255';
-            if (strstr(strtolower($column['type']), 'char') !== false && !empty($column['size'])) {
-                $length = 2 * $column['size'];
-            }
 
             $delimiter = '"\"' . $this->delimiter . '\""';
 

--- a/tests/data/config.json
+++ b/tests/data/config.json
@@ -30,7 +30,7 @@
             "name": "name",
             "dbName": "name",
             "type": "nvarchar",
-            "size": 255,
+            "size": "255",
             "nullable": null,
             "default": null
           },
@@ -38,7 +38,7 @@
             "name": "glasses",
             "dbName": "glasses",
             "type": "nvarchar",
-            "size": 255,
+            "size": "255",
             "nullable": null,
             "default": null
           }
@@ -54,7 +54,7 @@
             "name": "col1",
             "dbName": "col1",
             "type": "varchar",
-            "size": 255,
+            "size": "255",
             "nullable": null,
             "default": null
           },
@@ -62,7 +62,7 @@
             "name": "col2",
             "dbName": "col2",
             "type": "varchar",
-            "size": 255,
+            "size": "255",
             "nullable": null,
             "default": null
           }

--- a/tests/data/runFull/config.json
+++ b/tests/data/runFull/config.json
@@ -31,7 +31,7 @@
             "name": "name",
             "dbName": "name",
             "type": "nvarchar",
-            "size": 255,
+            "size": "255",
             "nullable": null,
             "default": null
           },
@@ -39,7 +39,7 @@
             "name": "glasses",
             "dbName": "glasses",
             "type": "nvarchar",
-            "size": 255,
+            "size": "255",
             "nullable": null,
             "default": null
           }
@@ -54,7 +54,7 @@
             "name": "col1",
             "dbName": "col1",
             "type": "nvarchar",
-            "size": 255,
+            "size": "255",
             "nullable": null,
             "default": null
           },
@@ -62,7 +62,7 @@
             "name": "col2",
             "dbName": "col2",
             "type": "nvarchar",
-            "size": 255,
+            "size": "max",
             "nullable": null,
             "default": null
           }
@@ -89,7 +89,7 @@
             "name": "name",
             "dbName": "name",
             "type": "varchar",
-            "size": 255,
+            "size": "255",
             "nullable": null,
             "default": null
           },
@@ -97,7 +97,7 @@
             "name": "glasses",
             "dbName": "glasses",
             "type": "varchar",
-            "size": 255,
+            "size": "255",
             "nullable": null,
             "default": null
           },
@@ -105,7 +105,7 @@
             "name": "nullable",
             "dbName": "nullable",
             "type": "varchar",
-            "size": 255,
+            "size": "255",
             "nullable": true,
             "default": ""
           }

--- a/tests/data/runFull/in/tables/special.csv
+++ b/tests/data/runFull/in/tables/special.csv
@@ -10,3 +10,5 @@ new line","columns with 	tab"
 "first","something with
 
 double new line"
+"ÅËŘΦҖԪڪڲݤੴ","utf"
+"long text", "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nullam fringilla risus ut neque efficitur cursus. Vivamus egestas fringilla iaculis. Maecenas interdum neque urna, sed imperdiet orci laoreet ac. Donec pharetra sagittis dolor at blandit. In mauris velit, laoreet et ante at, pharetra luctus mi. Ut vulputate, ex at accumsan tincidunt, nibh orci ullamcorper metus, blandit egestas nibh lectus quis diam. Praesent posuere velit id purus tincidunt, sed vehicula lectus varius. In nibh odio, sagittis ut facilisis vitae, mollis ut ipsum. Maecenas convallis nec orci vel lacinia."

--- a/tests/data/runFull/in/tables/special.csv
+++ b/tests/data/runFull/in/tables/special.csv
@@ -10,5 +10,4 @@ new line","columns with 	tab"
 "first","something with
 
 double new line"
-"ÅËŘΦҖԪڪڲݤੴ","utf"
-"long text", "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nullam fringilla risus ut neque efficitur cursus. Vivamus egestas fringilla iaculis. Maecenas interdum neque urna, sed imperdiet orci laoreet ac. Donec pharetra sagittis dolor at blandit. In mauris velit, laoreet et ante at, pharetra luctus mi. Ut vulputate, ex at accumsan tincidunt, nibh orci ullamcorper metus, blandit egestas nibh lectus quis diam. Praesent posuere velit id purus tincidunt, sed vehicula lectus varius. In nibh odio, sagittis ut facilisis vitae, mollis ut ipsum. Maecenas convallis nec orci vel lacinia."
+"long text","Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nullam fringilla risus ut neque efficitur cursus. Vivamus egestas fringilla iaculis. Maecenas interdum neque urna, sed imperdiet orci laoreet ac. Donec pharetra sagittis dolor at blandit. In mauris velit, laoreet et ante at, pharetra luctus mi. Ut vulputate, ex at accumsan tincidunt, nibh orci ullamcorper metus, blandit egestas nibh lectus quis diam. Praesent posuere velit id purus tincidunt, sed vehicula lectus varius. In nibh odio, sagittis ut facilisis vitae, mollis ut ipsum. Maecenas convallis nec orci vel lacinia."

--- a/tests/data/runIncremental/config.json
+++ b/tests/data/runIncremental/config.json
@@ -31,7 +31,7 @@
             "name": "Person",
             "dbName": "name",
             "type": "varchar",
-            "size": 255,
+            "size": "255",
             "nullable": null,
             "default": null
           },
@@ -39,7 +39,7 @@
             "name": "hasGlasses",
             "dbName": "glasses",
             "type": "varchar",
-            "size": 255,
+            "size": "255",
             "nullable": null,
             "default": null
           }
@@ -66,7 +66,7 @@
             "name": "Person",
             "dbName": "name",
             "type": "varchar",
-            "size": 255,
+            "size": "255",
             "nullable": null,
             "default": null
           },
@@ -74,7 +74,7 @@
             "name": "hasGlasses",
             "dbName": "glasses",
             "type": "varchar",
-            "size": 255,
+            "size": "255",
             "nullable": null,
             "default": null
           }
@@ -101,7 +101,7 @@
             "name": "Person",
             "dbName": "name",
             "type": "varchar",
-            "size": 255,
+            "size": "255",
             "nullable": null,
             "default": null
           },
@@ -109,7 +109,7 @@
             "name": "hasGlasses",
             "dbName": "glasses",
             "type": "varchar",
-            "size": 255,
+            "size": "255",
             "nullable": null,
             "default": null
           }


### PR DESCRIPTION
VARCHAR (MAX) data type was causing error in format file column length computation. Turned out that the computation is not necessary. I've added a test with long text column and data type VARCHAR(MAX).

First review and merge https://github.com/keboola/db-writer-mssql/pull/26!