### PR TITLE
COM-135: Create destination table properly on full load

### DIFF
--- a/src/MSSQL/Application.php
+++ b/src/MSSQL/Application.php
@@ -48,6 +48,7 @@ class Application extends \Keboola\DbWriter\Application
         $stageTable['dbName'] = $writer->generateTmpName($tableConfig['dbName']);
 
         $writer->drop($stageTable['dbName']);
+        $writer->create($stageTable);
         $writer->write($csv, $stageTable);
 
         // create destination table if not exists

--- a/src/Writer/MSSQL.php
+++ b/src/Writer/MSSQL.php
@@ -142,9 +142,9 @@ class MSSQL extends Writer implements WriterInterface
         }
 
         $query = sprintf(
-            'SELECT %s INTO %s FROM %s',
-            implode(',', $columns),
+            'INSERT INTO %s SELECT %s FROM %s',
             $this->escape($dstTableName),
+            implode(',', $columns),
             $this->escape($stagingTable['dbName'])
         );
         // if query fails drop the dst table
@@ -231,15 +231,15 @@ class MSSQL extends Writer implements WriterInterface
                 str_replace('.', '_', $table['dbName']),
                 implode('_', $table['primaryKey'])
             ));
-            $pkSql = PHP_EOL . sprintf(
+            $pkSql = sprintf(
                 'CONSTRAINT [%s] PRIMARY KEY CLUSTERED (%s)',
                 $constraintId,
                 implode(',', $table['primaryKey'])
-            ) . PHP_EOL;
+            );
         }
 
         $sql = sprintf(
-            'CREATE TABLE %s (%s %s)',
+            'CREATE TABLE %s (%s, %s)',
             $this->escape($table['dbName']),
             implode(',', $columnsSql),
             $pkSql

--- a/tests/phpunit/Writer/MSSQLSSHTest.php
+++ b/tests/phpunit/Writer/MSSQLSSHTest.php
@@ -74,6 +74,7 @@ class MSSQLSSHTest extends BaseTest
         $sourceFilename = $this->dataDir . '/' . $sourceTableId . '.csv';
 
         $this->writer->drop($outputTableName);
+        $this->writer->create($table);
         $this->writer->write(new CsvFile(realpath($sourceFilename)), $table);
 
         $conn = $this->writer->getConnection();
@@ -96,6 +97,7 @@ class MSSQLSSHTest extends BaseTest
         $sourceFilename = $this->dataDir . '/' . $sourceTableId . '.csv';
 
         $this->writer->drop($outputTableName);
+        $this->writer->create($table);
         $this->writer->write(new CsvFile(realpath($sourceFilename)), $table);
 
         $conn = $this->writer->getConnection();

--- a/tests/phpunit/Writer/MSSQLTest.php
+++ b/tests/phpunit/Writer/MSSQLTest.php
@@ -109,6 +109,7 @@ class MSSQLTest extends BaseTest
         $sourceFilename = $this->dataDir . '/' . $sourceTableId . '.csv';
 
         $this->writer->drop($outputTableName);
+        $this->writer->create($table);
         $this->writer->write(new CsvFile(realpath($sourceFilename)), $table);
 
         $conn = $this->writer->getConnection();
@@ -131,6 +132,7 @@ class MSSQLTest extends BaseTest
         $sourceFilename = $this->dataDir . '/' . $sourceTableId . '.csv';
 
         $this->writer->drop($outputTableName);
+        $this->writer->create($table);
         $this->writer->write(new CsvFile(realpath($sourceFilename)), $table);
 
         $conn = $this->writer->getConnection();
@@ -169,16 +171,21 @@ class MSSQLTest extends BaseTest
         $table = $tables[0];
         $sourceFilename = $this->dataDir . '/' . $table['tableId'] . '.csv';
         $targetTable = $table;
-        $table['dbName'] .= $table['incremental']?'_temp_' . uniqid():'';
 
-        // first write
+        // first write - create destination table
+        $this->writer->create($targetTable);
         $this->writer->write(new CsvFile($sourceFilename), $targetTable);
 
-        // second write
+        // second write - create stage table
+        $table['dbName'] .= $table['incremental']?'_temp_' . uniqid():'';
         $sourceFilename = $this->dataDir . '/' . $table['tableId'] . '_increment.csv';
+        $this->writer->create($table);
         $this->writer->write(new CsvFile($sourceFilename), $table);
+
+        // upsert to destination table
         $this->writer->upsert($table, $targetTable['dbName']);
 
+        // assert
         $stmt = $conn->query("SELECT * FROM {$targetTable['dbName']}");
         $res = $stmt->fetchAll(\PDO::FETCH_ASSOC);
 
@@ -203,6 +210,7 @@ class MSSQLTest extends BaseTest
         $sourceFilename = $this->dataDir . '/' . $table['tableId'] . '.csv';
 
         // first write
+        $this->writer->create($table);
         $this->writer->write(new CsvFile($sourceFilename), $table);
 
         // create index


### PR DESCRIPTION
- this issue wasn't fixed properly before. Even if the destination table was created beforehand, it got dropped in the MSSQL:write method, because the INSERT query failed on "table already exists", subsequent retry dropped the destination table and created new destination table from the staging table, but without Primary Keys.

- added proper test for data types and PKs