### PR TITLE
Don't remove dest table before retry.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,6 +15,7 @@
         "ext-PDO": "*",
         "keboola/csv": "^1.4",
         "keboola/db-writer-common": "^5.4",
+        "keboola/retry": "^0.5.0",
         "symfony/config": "^4.3",
         "symfony/process": "^3.4"
     },

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "5165e1711f425dd04152b3ebaeba39e1",
+    "content-hash": "777f71769388e9b193b0c5d65d96eac4",
     "packages": [
         {
             "name": "keboola/csv",
@@ -110,6 +110,57 @@
                 "writer"
             ],
             "time": "2020-04-03T06:28:24+00:00"
+        },
+        {
+            "name": "keboola/retry",
+            "version": "0.5.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/keboola/retry.git",
+                "reference": "afdb190a9186b30a27c75df2aaf24a6de07efebb"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/keboola/retry/zipball/afdb190a9186b30a27c75df2aaf24a6de07efebb",
+                "reference": "afdb190a9186b30a27c75df2aaf24a6de07efebb",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.1",
+                "psr/log": "^1.1"
+            },
+            "replace": {
+                "vkartaviy/retry": "*"
+            },
+            "require-dev": {
+                "keboola/coding-standard": "^7.0",
+                "phpstan/phpstan-shim": "^0.10",
+                "phpunit/phpunit": "7.*"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Retry\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Keboola Dev",
+                    "email": "devel@keboola.com"
+                }
+            ],
+            "description": "Library for repeatable and retryable operations",
+            "keywords": [
+                "backoff",
+                "proxy",
+                "repeat",
+                "retry"
+            ],
+            "time": "2020-01-31T14:20:00+00:00"
         },
         {
             "name": "keboola/ssh-tunnel",
@@ -2174,5 +2225,6 @@
         "php": "^7.1",
         "ext-pdo": "*"
     },
-    "platform-dev": []
+    "platform-dev": [],
+    "plugin-api-version": "1.1.0"
 }

--- a/src/Writer/MSSQL.php
+++ b/src/Writer/MSSQL.php
@@ -147,13 +147,8 @@ class MSSQL extends Writer implements WriterInterface
             implode(',', $columns),
             $this->escape($stagingTable['dbName'])
         );
-        // if query fails drop the dst table
-        $retryQuery = sprintf(
-            "IF OBJECT_ID('%s', 'U') IS NOT NULL DROP TABLE %s",
-            $dstTableName,
-            $this->escape($dstTableName)
-        );
-        $this->execQuery($query, $retryQuery);
+
+        $this->execQuery($query);
         $this->logger->info('BCP data moved to destination table');
 
         // drop staging
@@ -364,7 +359,7 @@ class MSSQL extends Writer implements WriterInterface
         return !empty($res);
     }
 
-    private function execQuery(string $query, ?string $retryQuery = null): void
+    private function execQuery(string $query): void
     {
         $this->logger->info(sprintf("Executing query: '%s'", $query));
 
@@ -384,11 +379,6 @@ class MSSQL extends Writer implements WriterInterface
                 sleep(pow($tries, 2));
                 $this->db = $this->createConnection($this->dbParams);
                 $tries++;
-
-                if (!is_null($retryQuery)) {
-                    $this->logger->info(sprintf("Executing retry query '%s'", $retryQuery));
-                    $this->db->exec($retryQuery);
-                }
             }
         }
 

--- a/tests/phpunit/Writer/MSSQLEntrypointTest.php
+++ b/tests/phpunit/Writer/MSSQLEntrypointTest.php
@@ -10,6 +10,14 @@ use Symfony\Component\Process\Process;
 
 class MSSQLEntrypointTest extends BaseTest
 {
+    private const BASIC_USER_LOGIN = 'basicUser';
+    private const BASIC_USER_PASSWORD = 'Abcdefg1234';
+    private const NO_PERM_USER_LOGIN = 'noPerm';
+    private const NO_PERM_USER_PASSWORD = 'pwd12334$%^&';
+
+    /** @var \PDO */
+    private $conn;
+
     /** @var string */
     private $rootPath = __DIR__ . '/../../../';
 
@@ -26,25 +34,81 @@ class MSSQLEntrypointTest extends BaseTest
 
         // create test database
         $dbParams = $config['parameters']['db'];
-        $conn = new \PDO(sprintf('sqlsrv:Server=%s', $dbParams['host']), $dbParams['user'], $dbParams['#password']);
-        $conn->setAttribute(\PDO::ATTR_ERRMODE, \PDO::ERRMODE_EXCEPTION);
-        $conn->exec('USE master');
-        $conn->exec(sprintf("
+        $this->conn = new \PDO(
+            sprintf('sqlsrv:Server=%s', $dbParams['host']),
+            $dbParams['user'],
+            $dbParams['#password']
+        );
+        $this->conn->setAttribute(\PDO::ATTR_ERRMODE, \PDO::ERRMODE_EXCEPTION);
+
+        // Drop database
+        $this->conn->exec('USE master');
+        $this->conn->exec(sprintf("
+            IF EXISTS(select * from sys.databases where name='%s')
+            ALTER DATABASE %s SET SINGLE_USER WITH ROLLBACK IMMEDIATE
+        ", $dbParams['database'], $dbParams['database']));
+        $this->conn->exec(sprintf("
             IF EXISTS(select * from sys.databases where name='%s') 
             DROP DATABASE %s
         ", $dbParams['database'], $dbParams['database']));
-        $conn->exec(sprintf('CREATE DATABASE %s COLLATE CZECH_CI_AS', $dbParams['database']));
-        $conn->exec(sprintf('USE %s', $dbParams['database']));
-        $conn->exec(sprintf('DROP USER IF EXISTS %s', 'basicUser'));
-        $conn->exec(sprintf("
+
+        // Create database
+        $this->conn->exec(sprintf('CREATE DATABASE %s COLLATE CZECH_CI_AS', $dbParams['database']));
+        $this->conn->exec(sprintf('USE %s', $dbParams['database']));
+
+        // Drop users
+        $this->conn->exec(sprintf('DROP USER IF EXISTS %s', self::BASIC_USER_LOGIN));
+        $this->conn->exec(sprintf("
             IF  EXISTS (SELECT * FROM sys.syslogins WHERE name = N'%s')
             DROP LOGIN %s
-        ", 'basicUser', 'basicUser'));
-        $conn->exec(sprintf("CREATE LOGIN %s WITH PASSWORD = '%s'", 'basicUser', 'Abcdefg1234'));
-        $conn->exec(sprintf('CREATE USER %s FOR LOGIN %s', 'basicUser', 'basicUser'));
-        $conn->exec(sprintf('GRANT CONTROL ON DATABASE::%s TO %s', $dbParams['database'], 'basicUser'));
-        $conn->exec(sprintf('GRANT CONTROL ON SCHEMA::%s TO %s', 'dbo', 'basicUser'));
-        $conn->exec(sprintf('REVOKE EXECUTE TO %s', 'basicUser'));
+        ", self::BASIC_USER_LOGIN, self::BASIC_USER_LOGIN));
+        $this->conn->exec(sprintf('DROP USER IF EXISTS %s', self::NO_PERM_USER_LOGIN));
+        $this->conn->exec(sprintf("
+            IF  EXISTS (SELECT * FROM sys.syslogins WHERE name = N'%s')
+            DROP LOGIN %s
+        ", self::NO_PERM_USER_LOGIN, self::NO_PERM_USER_LOGIN));
+
+        // Create login and users
+        $this->conn->exec(sprintf(
+            "CREATE LOGIN %s WITH PASSWORD = '%s'",
+            self::BASIC_USER_LOGIN,
+            self::BASIC_USER_PASSWORD
+        ));
+        $this->conn->exec(sprintf(
+            'CREATE USER %s FOR LOGIN %s',
+            self::BASIC_USER_LOGIN,
+            self::BASIC_USER_LOGIN
+        ));
+        $this->conn->exec(sprintf(
+            'GRANT CONTROL ON DATABASE::%s TO %s',
+            $dbParams['database'],
+            self::BASIC_USER_LOGIN
+        ));
+        $this->conn->exec(sprintf(
+            'GRANT CONTROL ON SCHEMA::%s TO %s',
+            'dbo',
+            self::BASIC_USER_LOGIN
+        ));
+        $this->conn->exec(sprintf(
+            'REVOKE EXECUTE TO %s',
+            self::BASIC_USER_LOGIN
+        ));
+        $this->conn->exec(sprintf(
+            "CREATE LOGIN %s WITH PASSWORD = '%s'",
+            self::NO_PERM_USER_LOGIN,
+            self::NO_PERM_USER_PASSWORD
+        ));
+        $this->conn->exec(sprintf(
+            'CREATE USER %s FOR LOGIN %s',
+            self::NO_PERM_USER_LOGIN,
+            self::NO_PERM_USER_LOGIN
+        ));
+        $this->conn->exec(sprintf(
+            'REVOKE EXECUTE TO %s',
+            self::NO_PERM_USER_LOGIN
+        ));
+
+        $this->conn->exec('USE test');
 
         $this->cleanup($config);
     }
@@ -74,7 +138,7 @@ class MSSQLEntrypointTest extends BaseTest
         $this->assertEquals('not null', $res[0]['nullable']);
 
         // check data types and keys
-        $query = 'SELECT 
+        $query = 'SELECT
                 c.name \'column_name\',
                 t.Name \'data_type\',
                 c.max_length \'max_length\',
@@ -199,7 +263,7 @@ class MSSQLEntrypointTest extends BaseTest
         $writer = $this->getWriter($config['parameters']);
         $writer->create($table);
         $writer->getConnection()->exec(sprintf('
-            CREATE NONCLUSTERED INDEX someIndexNameId 
+            CREATE NONCLUSTERED INDEX someIndexNameId
             ON %s (%s)
         ', $table['dbName'], 'name'));
 
@@ -326,6 +390,55 @@ class MSSQLEntrypointTest extends BaseTest
         $this->assertContains('errLine', $process->getErrorOutput());
         $this->assertContains('trace', $process->getErrorOutput());
         $this->assertContains('"class":"Keboola\\\\DbWriter\\\\Application"', $process->getErrorOutput());
+    }
+
+    public function testRetry(): void
+    {
+        $testDataSet = 'runIncremental';
+        $config = $this->initConfig($testDataSet);
+
+        // Modify config
+        unset($config['parameters']['tables'][0]);
+        unset($config['parameters']['tables'][2]);
+
+        $orgConfig = $config;
+        $table = $orgConfig['parameters']['tables'][1];
+
+        $config['parameters']['db']['user'] = self::NO_PERM_USER_LOGIN;
+        $config['parameters']['db']['#password'] = self::NO_PERM_USER_PASSWORD;
+        $this->initInputFiles($testDataSet, $config);
+
+        // Create table
+        $writer = $this->getWriter($orgConfig['parameters']);
+        $writer->create($table);
+
+        // Insert to table is denied
+        $this->conn->exec(sprintf('GRANT CONTROL ON DATABASE::test TO %s',self::NO_PERM_USER_LOGIN));
+        $this->conn->exec(sprintf('GRANT CONTROL ON SCHEMA::dbo TO %s',self::NO_PERM_USER_LOGIN));
+        $this->conn->exec(sprintf('DENY INSERT ON OBJECT::dbo.simple TO %s',self::NO_PERM_USER_LOGIN));
+
+        // Run app
+        $process = $this->runApp();
+
+        // Check retry in output
+        $output = $process->getOutput();
+        $errorOutput = $process->getErrorOutput();
+        $expectedError =
+            'The INSERT permission was denied ' .
+            'on the object \'simple\', database \'test\', schema \'dbo\'.';
+        $this->assertEquals(1, $process->getExitCode(), $process->getOutput());
+        $this->assertStringContainsString($expectedError . '. Retrying... [1x]', $output);
+        $this->assertStringContainsString($expectedError . '. Retrying... [2x]', $output);
+        $this->assertStringContainsString($expectedError . '. Retrying... [3x]', $output);
+        $this->assertStringContainsString($expectedError . '. Retrying... [4x]', $output);
+        $this->assertStringContainsString($expectedError, $errorOutput);
+
+        // Check table "simple" was not removed in retry
+        $this->assertNotEmpty(
+            $this->conn
+                ->query("SELECT * FROM test.INFORMATION_SCHEMA.TABLES WHERE TABLE_NAME = 'simple'")
+                ->fetchAll()
+        );
     }
 
     private function initInputFiles(string $subDir, ?array $config = null): array

--- a/tests/phpunit/Writer/MSSQLEntrypointTest.php
+++ b/tests/phpunit/Writer/MSSQLEntrypointTest.php
@@ -413,9 +413,9 @@ class MSSQLEntrypointTest extends BaseTest
         $writer->create($table);
 
         // Insert to table is denied
-        $this->conn->exec(sprintf('GRANT CONTROL ON DATABASE::test TO %s',self::NO_PERM_USER_LOGIN));
-        $this->conn->exec(sprintf('GRANT CONTROL ON SCHEMA::dbo TO %s',self::NO_PERM_USER_LOGIN));
-        $this->conn->exec(sprintf('DENY INSERT ON OBJECT::dbo.simple TO %s',self::NO_PERM_USER_LOGIN));
+        $this->conn->exec(sprintf('GRANT CONTROL ON DATABASE::test TO %s', self::NO_PERM_USER_LOGIN));
+        $this->conn->exec(sprintf('GRANT CONTROL ON SCHEMA::dbo TO %s', self::NO_PERM_USER_LOGIN));
+        $this->conn->exec(sprintf('DENY INSERT ON OBJECT::dbo.simple TO %s', self::NO_PERM_USER_LOGIN));
 
         // Run app
         $process = $this->runApp();

--- a/tests/phpunit/Writer/MSSQLSSHTest.php
+++ b/tests/phpunit/Writer/MSSQLSSHTest.php
@@ -10,6 +10,7 @@ use Keboola\DbWriter\Test\BaseTest;
 use Keboola\DbWriter\Writer\MSSQL;
 use Keboola\DbWriter\WriterFactory;
 use Monolog\Handler\TestHandler;
+use Symfony\Component\Process\Process;
 
 class MSSQLSSHTest extends BaseTest
 {
@@ -61,6 +62,15 @@ class MSSQLSSHTest extends BaseTest
 
         $writerFactory = new WriterFactory($this->config['parameters']);
         $this->writer = $writerFactory->create($logger);
+    }
+
+    protected function tearDown(): void
+    {
+        parent::tearDown();
+
+        # Close SSH tunnel if created
+        $process = new Process(['sh', '-c', 'pgrep ssh | xargs -r kill']);
+        $process->mustRun();
     }
 
     public function testWriteMssql(): void


### PR DESCRIPTION
Solving: https://keboola.atlassian.net/browse/COM-252

### Changes
- Destination table is not deleted on error before retry (`INSERT INTO`), it is bad and not needed.
- Added missing test on retry + `keboola/retry` is used.


### Problem
- It was necessary to delete the table on error in the past, where it was used:
`SELECT %s INTO %s FROM %s`, it **CREATES** table + insert values, https://github.com/keboola/db-writer-mssql/blob/e097199a0afc517856fe017be1496134eb7df419/src/Writer/MSSQL.php#L145

- See PR: https://github.com/keboola/db-writer-mssql/pull/42

- It was later changed to `INSERT INTO %s SELECT %s FROM %s`, it **ONLY INSERTS** rows to existing table https://github.com/keboola/db-writer-mssql/blob/15d81440a3ea9e598f70420c2d3bbefff38bdbae/src/Writer/MSSQL.php#L145
but delete statement wasn't deleted, so on error is table deleted but new is not created.

- See PR: https://github.com/keboola/db-writer-mssql/pull/60

- The table does not need to be deleted,
the `INSERT INTO` operation is ATOMIC in the relational database,
either everything is inserted and it is successful, or nothing is inserted.