### PR TITLE
Fix empty string to NOT NULL column

### DIFF
--- a/tests/data/runFull/config.json
+++ b/tests/data/runFull/config.json
@@ -32,7 +32,7 @@
             "dbName": "name",
             "type": "nvarchar",
             "size": "255",
-            "nullable": null,
+            "nullable": false,
             "default": null
           },
           {

--- a/tests/data/runFull/in/tables/nullable.csv
+++ b/tests/data/runFull/in/tables/nullable.csv
@@ -8,3 +8,4 @@
 "6","Petr Simecek","yes",""
 "7","Jakub Matejka","yes",""
 "8","Ondrej Popelka","no",""
+"9","","no",""


### PR DESCRIPTION
Jira: https://keboola.atlassian.net/browse/COM-753

V tejto komponente nahravame vsetko do stage tabulky ako `NVARCHAR NULL` a potom sa to snazime pretypovat.
Prazdny retazec v CSV sa vsak nahraje ako hodnota `NULL`.

Na pretopovanie sa pouziva:
![image](https://user-images.githubusercontent.com/19371734/115274733-46573a80-a141-11eb-9ade-299749782b0f.png)

Vysledkom je:
![image](https://user-images.githubusercontent.com/19371734/115274990-86b6b880-a141-11eb-8a79-1035df1b30fe.png)

---------------------------------------

Preto sa tam musi pridat `COALESCE`:
![image](https://user-images.githubusercontent.com/19371734/115275134-b9f94780-a141-11eb-90a3-6bb589a66df5.png)

Vysledkom je potom prazdny string;
![image](https://user-images.githubusercontent.com/19371734/115275172-c54c7300-a141-11eb-890d-9e2c90bee921.png)


