### PR TITLE
Dont use default PDO schema

### DIFF
--- a/src/Configuration/NodeDefinition/MSSQLDbNode.php
+++ b/src/Configuration/NodeDefinition/MSSQLDbNode.php
@@ -34,6 +34,6 @@ class MSSQLDbNode extends DbNode
 
     protected function addSchemaNode(NodeBuilder $builder): void
     {
-        $builder->scalarNode('schema')->defaultValue('dbo');
+        $builder->scalarNode('schema');
     }
 }

--- a/tests/functional/error-bcp-retry/expected-stdout
+++ b/tests/functional/error-bcp-retry/expected-stdout
@@ -1,40 +1,40 @@
 Creating PDO connection to "sqlsrv:Server=mssql;Database=test".
-Dropping table "dbo.simple"
-Creating table "dbo.simple"
+Dropping table "simple"
+Creating table "simple"
 BCP import started
-Dropping table "dbo.stage_%s_simple"
-Creating table "dbo.stage_%s_simple"
+Dropping table "stage_%s_simple"
+Creating table "stage_%s_simple"
 BCP staging table created
 BCP importing to staging table
 Format file:  %s
-Executing BCP command: ["bcp","dbo.[stage_%s_simple]","in","\/tmp\/%s","-f","\/tmpformat_file_stage_%s_simple_%s","-S","mssql,1433","-U","sa","-P","*****","-d","test","-k","-F2","-b50000","-e","\/tmp\/wr-db-mssql-errors","-m1"]
+Executing BCP command: ["bcp","[stage_%s_simple]","in","\/tmp\/%s","-f","\/tmpformat_file_stage_%s_simple_%s","-S","mssql,1433","-U","sa","-P","*****","-d","test","-k","-F2","-b50000","-e","\/tmp\/wr-db-mssql-errors","-m1"]
 Import process failed. Output:%s
-Dropping table "dbo.stage_%s_simple"
-Creating table "dbo.stage_%s_simple"
+Dropping table "stage_%s_simple"
+Creating table "stage_%s_simple"
 BCP staging table created
 BCP importing to staging table
 Format file:  %s
-Executing BCP command: ["bcp","dbo.[stage_%s_simple]","in","\/tmp\/%s","-f","\/tmpformat_file_stage_%s_simple_%s","-S","mssql,1433","-U","sa","-P","*****","-d","test","-k","-F2","-b50000","-e","\/tmp\/wr-db-mssql-errors","-m1"]
+Executing BCP command: ["bcp","[stage_%s_simple]","in","\/tmp\/%s","-f","\/tmpformat_file_stage_%s_simple_%s","-S","mssql,1433","-U","sa","-P","*****","-d","test","-k","-F2","-b50000","-e","\/tmp\/wr-db-mssql-errors","-m1"]
 Import process failed. Output:%s
-Dropping table "dbo.stage_%s_simple"
-Creating table "dbo.stage_%s_simple"
+Dropping table "stage_%s_simple"
+Creating table "stage_%s_simple"
 BCP staging table created
 BCP importing to staging table
 Format file:  %s
-Executing BCP command: ["bcp","dbo.[stage_%s_simple]","in","\/tmp\/%s","-f","\/tmpformat_file_stage_%s_simple_%s","-S","mssql,1433","-U","sa","-P","*****","-d","test","-k","-F2","-b50000","-e","\/tmp\/wr-db-mssql-errors","-m1"]
+Executing BCP command: ["bcp","[stage_%s_simple]","in","\/tmp\/%s","-f","\/tmpformat_file_stage_%s_simple_%s","-S","mssql,1433","-U","sa","-P","*****","-d","test","-k","-F2","-b50000","-e","\/tmp\/wr-db-mssql-errors","-m1"]
 Import process failed. Output:%s
-Dropping table "dbo.stage_%s_simple"
-Creating table "dbo.stage_%s_simple"
+Dropping table "stage_%s_simple"
+Creating table "stage_%s_simple"
 BCP staging table created
 BCP importing to staging table
 Format file:  %s
-Executing BCP command: ["bcp","dbo.[stage_%s_simple]","in","\/tmp\/%s","-f","\/tmpformat_file_stage_%s_simple_%s","-S","mssql,1433","-U","sa","-P","*****","-d","test","-k","-F2","-b50000","-e","\/tmp\/wr-db-mssql-errors","-m1"]
+Executing BCP command: ["bcp","[stage_%s_simple]","in","\/tmp\/%s","-f","\/tmpformat_file_stage_%s_simple_%s","-S","mssql,1433","-U","sa","-P","*****","-d","test","-k","-F2","-b50000","-e","\/tmp\/wr-db-mssql-errors","-m1"]
 Import process failed. Output:%s
-Dropping table "dbo.stage_%s_simple"
-Creating table "dbo.stage_%s_simple"
+Dropping table "stage_%s_simple"
+Creating table "stage_%s_simple"
 BCP staging table created
 BCP importing to staging table
 Format file:  %s
-Executing BCP command: ["bcp","dbo.[stage_%s_simple]","in","\/tmp\/%s","-f","\/tmpformat_file_stage_%s_simple_%s","-S","mssql,1433","-U","sa","-P","*****","-d","test","-k","-F2","-b50000","-e","\/tmp\/wr-db-mssql-errors","-m1"]
-Dropping table "dbo.stage_%s_simple"
+Executing BCP command: ["bcp","[stage_%s_simple]","in","\/tmp\/%s","-f","\/tmpformat_file_stage_%s_simple_%s","-S","mssql,1433","-U","sa","-P","*****","-d","test","-k","-F2","-b50000","-e","\/tmp\/wr-db-mssql-errors","-m1"]
+Dropping table "stage_%s_simple"
 BCP staging table dropped

--- a/tests/functional/error-insert-permission-denied/expected-stdout
+++ b/tests/functional/error-insert-permission-denied/expected-stdout
@@ -1,21 +1,21 @@
 Creating PDO connection to "sqlsrv:Server=mssql;Database=test".
-Dropping table "dbo.tmp_simple"
-Creating temporary table "dbo.tmp_simple"
+Dropping table "tmp_simple"
+Creating temporary table "tmp_simple"
 BCP import started
-Dropping table "dbo.stage_%s_tmp_simple"
-Creating table "dbo.stage_%s_tmp_simple"
+Dropping table "stage_%s_tmp_simple"
+Creating table "stage_%s_tmp_simple"
 BCP staging table created
 BCP importing to staging table
 Format file: %s
-Executing BCP command: ["bcp","dbo.[stage_%s_tmp_simple]","in","\/tmp\/%s","-f","\/%s","-S","mssql,1433","-U","noPerm","-P","*****","-d","test","-k","-F2","-b50000","-e","\/tmp\/wr-db-mssql-errors","-m1"]
+Executing BCP command: ["bcp","[stage_%s_tmp_simple]","in","\/tmp\/%s","-f","\/%s","-S","mssql,1433","-U","noPerm","-P","*****","-d","test","-k","-F2","-b50000","-e","\/tmp\/wr-db-mssql-errors","-m1"]
 BCP data imported to staging table
 BCP moving to destination table
 Found database server version: %s
 BCP data moved to destination table
-Dropping table "dbo.stage_%s_tmp_simple"
+Dropping table "stage_%s_tmp_simple"
 BCP staging table dropped
 BCP import finished
-Table "dbo.simple" has primary key, using upsert.
+Table "simple" has primary key, using upsert.
 SQLSTATE[42000]: [Microsoft][ODBC Driver 17 for SQL Server][SQL Server]The INSERT permission was denied on the object 'simple', database 'test', schema 'dbo'.. Retrying... [1x]
 SQLSTATE[42000]: [Microsoft][ODBC Driver 17 for SQL Server][SQL Server]The INSERT permission was denied on the object 'simple', database 'test', schema 'dbo'.. Retrying... [2x]
 SQLSTATE[42000]: [Microsoft][ODBC Driver 17 for SQL Server][SQL Server]The INSERT permission was denied on the object 'simple', database 'test', schema 'dbo'.. Retrying... [3x]

--- a/tests/functional/incremental-write-with-index/expected-stdout
+++ b/tests/functional/incremental-write-with-index/expected-stdout
@@ -1,20 +1,20 @@
 Creating PDO connection to "sqlsrv:Server=mssql;Database=test".
-Dropping table "dbo.tmp_simple"
-Creating temporary table "dbo.tmp_simple"
+Dropping table "tmp_simple"
+Creating temporary table "tmp_simple"
 BCP import started
-Dropping table "dbo.stage_%s_simple"
-Creating table "dbo.stage_%s_simple"
+Dropping table "stage_%s_simple"
+Creating table "stage_%s_simple"
 BCP staging table created
 BCP importing to staging table
 Format file: %s
-Executing BCP command: ["bcp","dbo.[stage_%s_simple]","in","\/tmp\/%s","-f","\/%s","-S","mssql,1433","-U","sa","-P","*****","-d","test","-k","-F2","-b50000","-e","\/tmp\/wr-db-mssql-errors","-m1"]
+Executing BCP command: ["bcp","[stage_%s_simple]","in","\/tmp\/%s","-f","\/%s","-S","mssql,1433","-U","sa","-P","*****","-d","test","-k","-F2","-b50000","-e","\/tmp\/wr-db-mssql-errors","-m1"]
 BCP data imported to staging table
 BCP moving to destination table
 Found database server version: %s
 BCP data moved to destination table
-Dropping table "dbo.stage_%s_simple"
+Dropping table "stage_%s_simple"
 BCP staging table dropped
 BCP import finished
-Table "dbo.simple" has primary key, using upsert.
-Data upserted to table "dbo.simple".
-Dropping table "dbo.tmp_simple"
+Table "simple" has primary key, using upsert.
+Data upserted to table "simple".
+Dropping table "tmp_simple"

--- a/tests/functional/incremental-write/expected-stdout
+++ b/tests/functional/incremental-write/expected-stdout
@@ -1,19 +1,19 @@
 Creating PDO connection to "sqlsrv:Server=mssql;Database=test".
-Dropping table "dbo.tmp_simple"
-Creating temporary table "dbo.tmp_simple"
+Dropping table "tmp_simple"
+Creating temporary table "tmp_simple"
 BCP import started
-Dropping table "dbo.stage_%s_simple"
-Creating table "dbo.stage_%s_simple"
+Dropping table "stage_%s_simple"
+Creating table "stage_%s_simple"
 BCP staging table created
 BCP importing to staging table
 Format file: %s
-Executing BCP command: ["bcp","dbo.[stage_%s_simple]","in","\/tmp\/%s","-f","\/%s","-S","mssql,1433","-U","sa","-P","*****","-d","test","-k","-F2","-b50000","-e","\/tmp\/wr-db-mssql-errors","-m1"]
+Executing BCP command: ["bcp","[stage_%s_simple]","in","\/tmp\/%s","-f","\/%s","-S","mssql,1433","-U","sa","-P","*****","-d","test","-k","-F2","-b50000","-e","\/tmp\/wr-db-mssql-errors","-m1"]
 BCP data imported to staging table
 BCP moving to destination table
 Found database server version: %s
 BCP data moved to destination table
-Dropping table "dbo.stage_%s_simple"
+Dropping table "stage_%s_simple"
 BCP staging table dropped
 BCP import finished
-Data upserted to table "dbo.simple".
-Dropping table "dbo.tmp_simple"
+Data upserted to table "simple".
+Dropping table "tmp_simple"

--- a/tests/functional/run-items-with-different-dbName/expected-stdout
+++ b/tests/functional/run-items-with-different-dbName/expected-stdout
@@ -1,17 +1,17 @@
 Creating PDO connection to "sqlsrv:Server=mssql;Database=test".
-Dropping table "dbo.db_simple"
-Creating table "dbo.db_simple"
+Dropping table "db_simple"
+Creating table "db_simple"
 BCP import started
-Dropping table "dbo.stage_%s_simple"
-Creating table "dbo.stage_%s_simple"
+Dropping table "stage_%s_simple"
+Creating table "stage_%s_simple"
 BCP staging table created
 BCP importing to staging table
 Format file: %s
-Executing BCP command: ["bcp","dbo.[stage_%s_simple]","in","\/tmp\/%s","-f","\/%s","-S","mssql,1433","-U","sa","-P","*****","-d","test","-k","-F2","-b50000","-e","\/tmp\/wr-db-mssql-errors","-m1"]
+Executing BCP command: ["bcp","[stage_%s_simple]","in","\/tmp\/%s","-f","\/%s","-S","mssql,1433","-U","sa","-P","*****","-d","test","-k","-F2","-b50000","-e","\/tmp\/wr-db-mssql-errors","-m1"]
 BCP data imported to staging table
 BCP moving to destination table
 Found database server version: %s
 BCP data moved to destination table
-Dropping table "dbo.stage_%s_simple"
+Dropping table "stage_%s_simple"
 BCP staging table dropped
 BCP import finished

--- a/tests/functional/run-row/expected-stdout
+++ b/tests/functional/run-row/expected-stdout
@@ -1,17 +1,17 @@
 Creating PDO connection to "sqlsrv:Server=mssql;Database=test".
-Dropping table "dbo.simple"
-Creating table "dbo.simple"
+Dropping table "simple"
+Creating table "simple"
 BCP import started
-Dropping table "dbo.stage_%s_simple"
-Creating table "dbo.stage_%s_simple"
+Dropping table "stage_%s_simple"
+Creating table "stage_%s_simple"
 BCP staging table created
 BCP importing to staging table
 Format file: %s
-Executing BCP command: ["bcp","dbo.[stage_%s_simple]","in","\/tmp\/%s","-f","\/%s","-S","mssql,1433","-U","sa","-P","*****","-d","test","-k","-F2","-b50000","-e","\/tmp\/wr-db-mssql-errors","-m1"]
+Executing BCP command: ["bcp","[stage_%s_simple]","in","\/tmp\/%s","-f","\/%s","-S","mssql,1433","-U","sa","-P","*****","-d","test","-k","-F2","-b50000","-e","\/tmp\/wr-db-mssql-errors","-m1"]
 BCP data imported to staging table
 BCP moving to destination table
 Found database server version: %s
 BCP data moved to destination table
-Dropping table "dbo.stage_%s_simple"
+Dropping table "stage_%s_simple"
 BCP staging table dropped
 BCP import finished

--- a/tests/functional/run-ssh-row/expected-stdout
+++ b/tests/functional/run-ssh-row/expected-stdout
@@ -1,18 +1,18 @@
 Creating SSH tunnel to 'sshproxy' on local port '1234'
 Creating PDO connection to "sqlsrv:Server=127.0.0.1,1234;Database=test".
-Dropping table "dbo.simple"
-Creating table "dbo.simple"
+Dropping table "simple"
+Creating table "simple"
 BCP import started
-Dropping table "dbo.stage_%s_simple"
-Creating table "dbo.stage_%s_simple"
+Dropping table "stage_%s_simple"
+Creating table "stage_%s_simple"
 BCP staging table created
 BCP importing to staging table
 Format file: %s
-Executing BCP command: ["bcp","dbo.[stage_%s_simple]","in","\/tmp\/%s","-f","\/%s","-S","127.0.0.1,1234","-U","sa","-P","*****","-d","test","-k","-F2","-b50000","-e","\/tmp\/wr-db-mssql-errors","-m1"]
+Executing BCP command: ["bcp","[stage_%s_simple]","in","\/tmp\/%s","-f","\/%s","-S","127.0.0.1,1234","-U","sa","-P","*****","-d","test","-k","-F2","-b50000","-e","\/tmp\/wr-db-mssql-errors","-m1"]
 BCP data imported to staging table
 BCP moving to destination table
 Found database server version: %s
 BCP data moved to destination table
-Dropping table "dbo.stage_%s_simple"
+Dropping table "stage_%s_simple"
 BCP staging table dropped
 BCP import finished

--- a/tests/functional/run-text-column/expected-stdout
+++ b/tests/functional/run-text-column/expected-stdout
@@ -1,17 +1,17 @@
 Creating PDO connection to "sqlsrv:Server=mssql;Database=test".
-Dropping table "dbo.text"
-Creating table "dbo.text"
+Dropping table "text"
+Creating table "text"
 BCP import started
-Dropping table "dbo.stage_%s_text"
-Creating table "dbo.stage_%s_text"
+Dropping table "stage_%s_text"
+Creating table "stage_%s_text"
 BCP staging table created
 BCP importing to staging table
 Format file: %s
-Executing BCP command: ["bcp","dbo.[stage_%s_text]","in","\/tmp\/%s","-f","\/%s","-S","mssql,1433","-U","sa","-P","*****","-d","test","-k","-F2","-b50000","-e","\/tmp\/wr-db-mssql-errors","-m1"]
+Executing BCP command: ["bcp","[stage_%s_text]","in","\/tmp\/%s","-f","\/%s","-S","mssql,1433","-U","sa","-P","*****","-d","test","-k","-F2","-b50000","-e","\/tmp\/wr-db-mssql-errors","-m1"]
 BCP data imported to staging table
 BCP moving to destination table
 Found database server version: %s
 BCP data moved to destination table
-Dropping table "dbo.stage_%s_text"
+Dropping table "stage_%s_text"
 BCP staging table dropped
 BCP import finished

--- a/tests/functional/run-with-basic-user/expected-stdout
+++ b/tests/functional/run-with-basic-user/expected-stdout
@@ -1,17 +1,17 @@
 Creating PDO connection to "sqlsrv:Server=mssql;Database=test".
-Dropping table "dbo.simple"
-Creating table "dbo.simple"
+Dropping table "simple"
+Creating table "simple"
 BCP import started
-Dropping table "dbo.stage_%s_simple"
-Creating table "dbo.stage_%s_simple"
+Dropping table "stage_%s_simple"
+Creating table "stage_%s_simple"
 BCP staging table created
 BCP importing to staging table
 Format file: %s
-Executing BCP command: ["bcp","dbo.[stage_%s_simple]","in","\/tmp\/%s","-f","\/%s","-S","mssql,1433","-U","basicUser","-P","*****","-d","test","-k","-F2","-b50000","-e","\/tmp\/wr-db-mssql-errors","-m1"]
+Executing BCP command: ["bcp","[stage_%s_simple]","in","\/tmp\/%s","-f","\/%s","-S","mssql,1433","-U","basicUser","-P","*****","-d","test","-k","-F2","-b50000","-e","\/tmp\/wr-db-mssql-errors","-m1"]
 BCP data imported to staging table
 BCP moving to destination table
 Found database server version: %s
 BCP data moved to destination table
-Dropping table "dbo.stage_%s_simple"
+Dropping table "stage_%s_simple"
 BCP staging table dropped
 BCP import finished


### PR DESCRIPTION
Ze supportu - https://keboola.atlassian.net/browse/SUPPORT-10184?focusedCommentId=142795&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-142795

sice v [původní verzi](https://github.com/keboola/db-writer-mssql/blob/4.11.0/src/MSSQL/Configuration/MssqlConfigDefinition.php#L42) bylo pdo jako výchozí schéma, ale to nastavení se nikde při zápisu nepoužívalo :/ 

takže tím že jsme to začali používat tak tím to vynutíme a nerespektujeme to co má user jako default schema - na což klient právě psal

v UI ani schema nastavit nejde takže je to nepoužívané, ale tu logiku bych tam nechal v ExportConfigu kdyby se v budoucnu toto nastavení začalo používat